### PR TITLE
fix: drop unused second argument from run_notebook call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           
           # Run all notebooks
           run_notebook "deploy/1_HuggingFace_Safetensors.ipynb" || exit 1
-          run_notebook "deploy/2_TRTLLM_Checkpoints_Engines.ipynb" "fix_trtllm_path" || exit 1
+          run_notebook "deploy/2_TRTLLM_Checkpoints_Engines.ipynb" || exit 1
           run_notebook "deploy/3_GGUF_Checkpoints.ipynb" || exit 1
 
       - name: Convert results to HTML format

--- a/tests/test_ci_dead_code_arg.sh
+++ b/tests/test_ci_dead_code_arg.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+WORKFLOW=".github/workflows/ci.yml"
+
+if grep -q 'run_notebook "deploy/2_TRTLLM_Checkpoints_Engines.ipynb" "fix_trtllm_path"' "$WORKFLOW"; then
+    echo "FAIL: run_notebook still receives unused second argument"
+    exit 1
+fi
+


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/ci.yml`: drop unused second argument from run_notebook call.

## Changes
- `.github/workflows/ci.yml`: drop unused second argument from run_notebook call.

## Details
```diff
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,1 +1,1 @@
-          run_notebook "deploy/2_TRTLLM_Checkpoints_Engines.ipynb" "fix_trtllm_path" || exit 1
+          run_notebook "deploy/2_TRTLLM_Checkpoints_Engines.ipynb" || exit 1
```

## Tests
- `tests/test_ci_dead_code_arg.sh`

```diff
--- /dev/null
+++ b/tests/test_ci_dead_code_arg.sh
@@ -0,0 +1,9 @@
+#!/bin/bash
+set -e
+WORKFLOW=".github/workflows/ci.yml"
+
+if grep -q 'run_notebook "deploy/2_TRTLLM_Checkpoints_Engines.ipynb" "fix_trtllm_path"' "$WORKFLOW"; then
+    echo "FAIL: run_notebook still receives unused second argument"
+    exit 1
+fi
+
+echo "PASS"
```