### PR TITLE
fix: missing papermill and nbconvert install breaks notebook steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: |          
           echo "Installing ipykernel ..."
           python -m pip install --upgrade pip
-          pip install ipykernel
+          pip install ipykernel papermill nbconvert
           echo "Installing Python kernel..."
           python -m ipykernel install --user --name python3 --display-name "Python 3"
           

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -14,9 +14,9 @@ class TestCIWorkflow(unittest.TestCase):
         text = WORKFLOW.read_text()
         pip_lines = [
             line.strip() for line in text.splitlines()
-            if line.strip().startswith("pip install")
+            if line.strip().startswith("pip install ipykernel")
         ]
-        self.assertTrue(pip_lines, "No pip install command found in workflow")
+        self.assertTrue(pip_lines, "No notebook dependency install command found in workflow")
         installs = " ".join(pip_lines)
         self.assertIn("papermill", installs)
         self.assertIn("nbconvert", installs)

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -17,3 +17,6 @@ class TestCIWorkflow(unittest.TestCase):
             if line.strip().startswith("pip install")
         ]
         self.assertTrue(pip_lines, "No pip install command found in workflow")
+        installs = " ".join(pip_lines)
+        self.assertIn("papermill", installs)
+        self.assertIn("nbconvert", installs)

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,19 @@
+import pathlib
+import unittest
+
+WORKFLOW = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / ".github"
+    / "workflows"
+    / "ci.yml"
+)
+
+
+class TestCIWorkflow(unittest.TestCase):
+    def test_notebook_dependencies_installed(self):
+        text = WORKFLOW.read_text()
+        pip_lines = [
+            line.strip() for line in text.splitlines()
+            if line.strip().startswith("pip install")
+        ]
+        self.assertTrue(pip_lines, "No pip install command found in workflow")


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/ci.yml`: missing papermill and nbconvert install breaks notebook steps.

## Changes
- `.github/workflows/ci.yml`: missing papermill and nbconvert install breaks notebook steps.

## Details
```diff
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-          echo "Installing ipykernel ..."
-          python -m pip install --upgrade pip
-          pip install ipykernel
-          echo "Installing Python kernel..."
+          echo "Installing ipykernel ..."
+          python -m pip install --upgrade pip
+          pip install ipykernel papermill nbconvert
+          echo "Installing Python kernel..."
```

## Tests
- `tests/test_ci_workflow.py`

```diff
diff --git a/tests/test_ci_workflow.py b/tests/test_ci_workflow.py
new file mode 100644
index 0000000..e69ade1
--- /dev/null
+++ b/tests/test_ci_workflow.py
@@ -0,0 +1,19 @@
+import pathlib
+import unittest
+
+WORKFLOW = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / ".github"
+    / "workflows"
+    / "ci.yml"
+)
+
+
+class TestCIWorkflow(unittest.TestCase):
+    def test_notebook_dependencies_installed(self):
+        text = WORKFLOW.read_text()
+        pip_lines = [
+            line.strip() for line in text.splitlines()
+            if line.strip().startswith("pip install")
+        ]
+        self.assertTrue(pip_lines, "No pip install command found in workflow")
+        installs = " ".join(pip_lines)
+        self.assertIn("papermill", installs)
+        self.assertIn("nbconvert", installs)
```